### PR TITLE
dplyr 1.0.8 compatibility: avoid using matrices in `filter()`

### DIFF
--- a/R/cfa_groupwise.R
+++ b/R/cfa_groupwise.R
@@ -54,7 +54,7 @@ cfa_groupwise <- function(data,
   return_df <- data.frame(group = NULL, cfi = NULL, rmsea = NULL, tli = NULL)
   for (i in groups) {
     cfa_data <- data %>%
-      dplyr::filter(dplyr::across(!!group) == i)
+      dplyr::filter(dplyr::across(!!group)[[1]] == i)
     cfa_model_summary <- lavaan::cfa(model = model, data = cfa_data, ordered = ordered)
     cfa_model_summary <- as.data.frame(lavaan::fitmeasures(cfa_model_summary))
     summary_df <- data.frame(group = i, cfi = cfa_model_summary["cfi", ], rmsea = cfa_model_summary["rmsea", ], tli = cfa_model_summary["tli", ])


### PR DESCRIPTION
We're in the process of releasing dplyr 1.0.8 and this package was identified as failing by our rev dep checks. This is because `filter()` is getting stricter about not allowing matrices. see https://github.com/tidyverse/dplyr/pull/6083

`dplyr::across(!!group) == i` gives a matrix. 

We might merge https://github.com/tidyverse/dplyr/pull/6083 in dplyr which would make the package pass anyway, but nevertheless I think it's a good patch. 

````
── After ─────────────────────────────────────────────────────────────────────────────────────────────────────
> checking examples ... ERROR
  Running examples in ‘psycModel-Ex.R’ failed
  The error most likely occurred in:
  
  > ### Name: cfa_groupwise
  > ### Title: Confirmatory Factor Analysis (groupwise)
  > ### Aliases: cfa_groupwise
  > 
  > ### ** Examples
  > 
  > # The example is used as the illustration of the function output only.
  > # It does not imply the data is appropriate for the analysis.
  > cfa_groupwise(
  +   data = lavaan::HolzingerSwineford1939,
  +   group = "school",
  +   x1:x3,
  +   x4:x6,
  +   x7:x9
  + )
  Error: Problem while computing `..1 = dplyr::across("school") == i`.
  ✖ Input `..1` must be a logical vector, not a logical[,1].
  Backtrace:
       ▆
    1. ├─psycModel::cfa_groupwise(...)
    2. │ └─data %>% dplyr::filter(dplyr::across(!!group) == i)
    3. ├─dplyr::filter(., dplyr::across(!!group) == i)
    4. ├─dplyr:::filter.data.frame(., dplyr::across(!!group) == i)
    5. │ └─dplyr:::filter_rows(.data, ..., caller_env = caller_env())
    6. │   └─dplyr:::filter_eval(dots, mask = mask, error_call = error_call)
    7. │     ├─base::withCallingHandlers(...)
    8. │     └─mask$eval_all_filter(dots, env_filter)
    9. ├─dplyr:::dplyr_internal_error(...)
   10. │ └─rlang::abort(class = c(class, "dplyr:::internal_error"), dplyr_error_data = data)
   11. │   └─rlang:::signal_abort(cnd, .file)
   12. │     └─base::signalCondition(cnd)
   13. └─dplyr `<fn>`(`<dpl:::__>`)
  Execution halted

> checking dependencies in R code ... NOTE
  Namespaces in Imports field not imported from:
    ‘lifecycle’ ‘patchwork’
    All declared Imports should be used.

1 error x | 0 warnings ✓ | 1 note x
````